### PR TITLE
add missing playerId type definition to protocol21029.py

### DIFF
--- a/s2protocol/versions/protocol21029.py
+++ b/s2protocol/versions/protocol21029.py
@@ -169,6 +169,7 @@ typeinfos = [
     ('_struct',[[('m_recipient',17,-3),('m_string',22,-2)]]),  #142
     ('_struct',[[('m_recipient',17,-3),('m_point',67,-2)]]),  #143
     ('_struct',[[('m_progress',66,-2)]]),  #144
+    ('_struct',[[('m_playerId',37,-1)]]),  #145
 ]
 
 # Map from protocol NNet.Game.*Event eventid to (typeid, name)
@@ -279,7 +280,7 @@ tracker_eventid_typeid = None
 svaruint32_typeid = 6
 
 # The typeid of NNet.Replay.SGameUserId (the type used to encode player ids).
-replay_userid_typeid = None
+replay_userid_typeid = 145
 
 # The typeid of NNet.Replay.SHeader (the type used to store replay game version and length).
 replay_header_typeid = 11


### PR DESCRIPTION
Discovered when I updated my (ancient) library to the latest and could no
longer decode the game events in one of my saved replays. It seems that at
some point last year these protocol files were regenerated, and the resulting
file for 21029 (and possibly others) have set the replay_userid_typeid to
None, and the corresponding struct definition is missing. This is a big
problem, because the userIds can still be found in the "replay.game.events"
stream, but now the decoders have no way to decode or skip over them (and
then incorrectly decode the remaining bits). Also worth noting is that the
type *can* still be found in the protocol21029.json schema definition.

Fixed by adding the type back in, by comparing with my old version of the
protocol. It has one field dependent on a 5-bit "_int" type, which can be
found as entry 37 in the type list. It's entirely possible other protocol
versions are affected, and if these files are automatically generated, then
this is probably not the preferred approach to fixing this type of omission.