### PR TITLE
Support Python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ env
 dist
 build
 *.egg-info
+
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install:
 # command to run tests
 script:
   - tox
-  - python s2_cli.py --all --ndjson --profile tests\s2replaystatsdata\2018_05_17_Z_Raphtor_VS_T_Tocon.SC2Replay

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ install:
 # command to run tests
 script:
   - tox
+  - python s2_cli.py --all --ndjson --profile tests\s2replaystatsdata\2018_05_17_Z_Raphtor_VS_T_Tocon.SC2Replay

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: python
 python:
   - "2.7"
   - "3.6"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - pip install tox-travis
 # command to run tests
 script:
-  - python tests/suite.py
+  - tox

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some notes on tracker events:
 
 ```python
     unitIndex = event['m_firstUnitIndex']
-    for i in xrange(0, len(event['m_items']), 3):
+    for i in range(0, len(event['m_items']), 3):
         unitIndex += event['m_items'][i + 0]
         x = event['m_items'][i + 1] * 4
         y = event['m_items'][i + 2] * 4

--- a/s2protocol/compat.py
+++ b/s2protocol/compat.py
@@ -1,5 +1,4 @@
 import sys
-
 __all__ = 'byte_to_int',
 
 

--- a/s2protocol/compat.py
+++ b/s2protocol/compat.py
@@ -1,9 +1,20 @@
 import sys
-__all__ = 'byte_to_int',
+import io
+
+__all__ = 'PY3', 'byte_to_int', 'get_stream'
+PY3 = sys.version_info.major == 3
 
 
 def byte_to_int(x):
-    if sys.version_info.major == 3 and isinstance(x, (bytes, int)):
+    if PY3 and isinstance(x, (bytes, int)):
         return x
     else:
         return ord(x)
+
+
+def get_stream():
+    if PY3:
+        cls = io.StringIO
+    else:
+        cls = io.BytesIO
+    return cls()

--- a/s2protocol/compat.py
+++ b/s2protocol/compat.py
@@ -4,7 +4,7 @@ __all__ = 'byte_to_int',
 
 
 def byte_to_int(x):
-    if sys.version_info.major == 3 and isinstance(x, bytes):
+    if sys.version_info.major == 3 and isinstance(x, (bytes, int)):
         return x
     else:
         return ord(x)

--- a/s2protocol/compat.py
+++ b/s2protocol/compat.py
@@ -1,10 +1,10 @@
-from six import PY3, binary_type
+import sys
 
 __all__ = 'byte_to_int',
 
 
 def byte_to_int(x):
-    if PY3 and isinstance(x, binary_type):
+    if sys.version_info.major == 3 and isinstance(x, bytes):
         return x
     else:
         return ord(x)

--- a/s2protocol/compat.py
+++ b/s2protocol/compat.py
@@ -1,0 +1,10 @@
+from six import PY3, binary_type
+
+__all__ = 'byte_to_int',
+
+
+def byte_to_int(x):
+    if PY3 and isinstance(x, binary_type):
+        return x
+    else:
+        return ord(x)

--- a/s2protocol/decoders.py
+++ b/s2protocol/decoders.py
@@ -88,7 +88,7 @@ class BitPackedBuffer:
         return result
 
     def read_unaligned_bytes(self, bytes):
-        return ''.join([chr(self.read_bits(8)) for i in xrange(bytes)])
+        return ''.join([chr(self.read_bits(8)) for i in range(bytes)])
 
 
 class BitPackedDecoder:
@@ -117,7 +117,7 @@ class BitPackedDecoder:
 
     def _array(self, bounds, typeid):
         length = self._int(bounds)
-        return [self.instance(typeid) for i in xrange(length)]
+        return [self.instance(typeid) for i in range(length)]
 
     def _bitarray(self, bounds):
         length = self._int(bounds)
@@ -214,7 +214,7 @@ class VersionedDecoder:
     def _array(self, bounds, typeid):
         self._expect_skip(0)
         length = self._vint()
-        return [self.instance(typeid) for i in xrange(length)]
+        return [self.instance(typeid) for i in range(length)]
 
     def _bitarray(self, bounds):
         self._expect_skip(1)
@@ -267,7 +267,7 @@ class VersionedDecoder:
         self._expect_skip(5)
         result = {}
         length = self._vint()
-        for i in xrange(length):
+        for i in range(length):
             tag = self._vint()
             field = next((f for f in fields if f[2] == tag), None)
             if field:
@@ -289,7 +289,7 @@ class VersionedDecoder:
         skip = self._buffer.read_bits(8)
         if skip == 0:  # array
             length = self._vint()
-            for i in xrange(length):
+            for i in range(length):
                 self._skip_instance()
         elif skip == 1:  # bitblob
             length = self._vint()
@@ -306,7 +306,7 @@ class VersionedDecoder:
                 self._skip_instance()
         elif skip == 5:  # struct
             length = self._vint()
-            for i in xrange(length):
+            for i in range(length):
                 tag = self._vint()
                 self._skip_instance()
         elif skip == 6:  # u8

--- a/s2protocol/decoders.py
+++ b/s2protocol/decoders.py
@@ -20,6 +20,8 @@
 
 import struct
 
+from .compat import byte_to_int
+
 
 class TruncatedError(Exception):
     pass
@@ -66,7 +68,7 @@ class BitPackedBuffer:
             if self._nextbits == 0:
                 if self.done():
                     raise TruncatedError(self)
-                self._next = ord(self._data[self._used])
+                self._next = byte_to_int(self._data[self._used])
                 self._used += 1
                 self._nextbits = 8
             copybits = min(bits - resultbits, self._nextbits)

--- a/s2protocol/decoders.py
+++ b/s2protocol/decoders.py
@@ -40,9 +40,14 @@ class BitPackedBuffer:
         self._bigendian = (endian == 'big')
 
     def __str__(self):
-        return 'buffer(%02x/%d,[%d]=%s)' % (
-            self._nextbits and self._next or 0, self._nextbits,
-            self._used, '%02x' % (ord(self._data[self._used]),) if (self._used < len(self._data)) else '--')
+        s = '{:02x}'.format(byte_to_int(self._data[self._used])) \
+            if self._used < len(self._data) else '--'
+        return 'buffer({0:02x}/{1:d},[{2:d}]={3:s})'.format(
+            self._nextbits and self._next or 0,
+            self._nextbits,
+            self._used,
+            s
+        )
 
     def done(self):
         return self._nextbits == 0 and self._used >= len(self._data)

--- a/s2protocol/diff.py
+++ b/s2protocol/diff.py
@@ -8,7 +8,7 @@ import sys
 import argparse
 import pprint
 
-import versions
+from .versions import build
 
 def diff_things(typeinfo_index, thing_a, thing_b):
     if type(thing_a) != type(thing_b):
@@ -56,8 +56,8 @@ def diff(protocol_a_ver, protocol_b_ver):
         )
     )
 
-    protocol_a = versions.build(protocol_a_ver)
-    protocol_b = versions.build(protocol_b_ver)
+    protocol_a = build(protocol_a_ver)
+    protocol_b = build(protocol_b_ver)
     count_a = len(protocol_a.typeinfos)
     count_b = len(protocol_b.typeinfos)
     print("Count of typeinfos: {} {}".format(count_a, count_b))

--- a/s2protocol/diff.py
+++ b/s2protocol/diff.py
@@ -44,7 +44,7 @@ def diff(protocol_a_ver, protocol_b_ver):
     print >> sys.stdout, "Count of typeinfos: {} {}".format(
             count_a, count_b)
 
-    for index in xrange(max(count_a, count_b)):
+    for index in range(max(count_a, count_b)):
         if index >= count_a:
             print >> sys.stdout, "Protocol {} missing typeinfo {}".format(protocol_a_ver, index)
             continue

--- a/s2protocol/diff.py
+++ b/s2protocol/diff.py
@@ -12,7 +12,11 @@ import versions
 
 def diff_things(typeinfo_index, thing_a, thing_b):
     if type(thing_a) != type(thing_b):
-        print >> sys.stdout, "typeinfo {} diff types: {} {}".format(typeinfo_index, type(thing_a), type(thing_b))
+        print(
+            "typeinfo {} diff types: {} {}".format(
+                typeinfo_index, type(thing_a), type(thing_b)
+            )
+        )
         return
 
     if type(thing_a) == dict:
@@ -21,35 +25,48 @@ def diff_things(typeinfo_index, thing_a, thing_b):
          
     if type(thing_a) == list or type(thing_a) == tuple:
         if len(thing_a) != len(thing_b):
-            print >> sys.stdout, "typeinfo {} diff len: {} {}".format(typeinfo_index, len(thing_a), len(thing_b))
+            print(
+                "typeinfo {} diff len: {} {}".format(
+                    typeinfo_index, len(thing_a), len(thing_b)
+                )
+            )
         else:
             for ix in range(len(thing_a)):
                 diff_things(typeinfo_index, thing_a[ix], thing_b[ix])
     elif thing_a != thing_b:
         if type(thing_a) == int:
             if (thing_a < 55 or thing_a - 1 != thing_b):
-                print >> sys.stdout, "typeinfo {} diff number: {} {}".format(typeinfo_index, thing_a, thing_b)
+                print(
+                    "typeinfo {} diff number: {} {}".format(
+                        typeinfo_index, thing_a, thing_b
+                    )
+                )
         else:
-            print >> sys.stdout, "typeinfo {} diff string: {} {}".format(typeinfo_index, thing_a, thing_b)
+            print(
+                "typeinfo {} diff string: {} {}".format(
+                    typeinfo_index, thing_a, thing_b
+                )
+            )
             
 
 def diff(protocol_a_ver, protocol_b_ver):
-    print >> sys.stdout, "Comparing {} to {}".format(
-            protocol_a_ver, protocol_b_ver)
+    print(
+        "Comparing {} to {}".format(
+            protocol_a_ver, protocol_b_ver
+        )
+    )
 
     protocol_a = versions.build(protocol_a_ver)
     protocol_b = versions.build(protocol_b_ver)
     count_a = len(protocol_a.typeinfos)
     count_b = len(protocol_b.typeinfos)
-    print >> sys.stdout, "Count of typeinfos: {} {}".format(
-            count_a, count_b)
-
+    print("Count of typeinfos: {} {}".format(count_a, count_b))
     for index in range(max(count_a, count_b)):
         if index >= count_a:
-            print >> sys.stdout, "Protocol {} missing typeinfo {}".format(protocol_a_ver, index)
+            print("Protocol {} missing typeinfo {}".format(protocol_a_ver, index))
             continue
         if index >= count_b:
-            print >> sys.stdout, "Protocol {} missing typeinfo {}".format(protocol_b_ver, index)
+            print("Protocol {} missing typeinfo {}".format(protocol_b_ver, index))
             continue
         a = protocol_a.typeinfos[index]
         b = protocol_b.typeinfos[index]

--- a/s2protocol/encoders.py
+++ b/s2protocol/encoders.py
@@ -20,6 +20,8 @@
 
 import struct
 
+from .compat import byte_to_int
+
 class IncompleteError(Exception):
     pass
 
@@ -68,7 +70,7 @@ class BitPackedBuffer:
     def write_unaligned_bytes(self, data):
         assert isinstance(data, str)
         for c in data:
-            self.write_bits(ord(c), 8)
+            self.write_bits(byte_to_int(c), 8)
 
 class BitPackedEncoder:
     def __init__(self, output, typeinfos):

--- a/s2protocol/encoders.py
+++ b/s2protocol/encoders.py
@@ -114,7 +114,7 @@ class BitPackedEncoder:
     def _choice(self, value, bounds, fields):
         #assert isinstance(value, dict)
         assert len(value) == 1
-        for tag, field in fields.iteritems():
+        for tag, field in fields.items():
             if field[0] in value:
                 self._int(tag, bounds)
                 self.instance(value[field[0]], field[1])
@@ -224,7 +224,7 @@ class VersionedEncoder:
         #assert isinstance(value, dict)
         assert len(value) == 1
         self._write_skip(3)
-        for tag, field in fields.iteritems():
+        for tag, field in fields.items():
             if field[0] in value:
                 self._vint(tag)
                 self.instance(value[field[0]], field[1])

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -47,7 +47,7 @@ class NDJSONOutputFilter(EventFilter):
         self._output = output
 
     def process(self, event):
-        print(self._output, json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True))
+        print(json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True), file=self._output)
         return event
 
 

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import sys
 import argparse
@@ -16,6 +17,8 @@ import attributes as _attr
 import cProfile
 import pstats
 import StringIO
+
+
 
 
 class EventFilter(object):
@@ -297,8 +300,7 @@ def main():
     try:
         protocol = versions.build(baseBuild)
     except Exception as e:
-        print('Unsupported base build: {0} ({1!s})'.format(baseBuild, e),
-              file=sys.stderr)
+        print('Unsupported base build: {0} ({1!s})'.format(baseBuild, e), file=sys.stderr)
         sys.exit(1)
 
     # Process game metadata

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -34,7 +34,7 @@ class JSONOutputFilter(EventFilter):
         self._output = output
 
     def process(self, event):
-        print >> self._output, json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True, indent=4)
+        print(json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True, indent=4))
         return event
 
 
@@ -44,7 +44,7 @@ class NDJSONOutputFilter(EventFilter):
         self._output = output
 
     def process(self, event):
-        print >> self._output, json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True)
+        print(self._output, json.dumps(event, encoding='ISO-8859-1', ensure_ascii=True))
         return event
 
 
@@ -91,7 +91,7 @@ class StatCollectionFilter(EventFilter):
         return event
 
     def finish(self):
-        print >> sys.stdout, 'Name, Count, Bits'
+        print('Name, Count, Bits')
         for name, stat in sorted(self._event_stats.iteritems(), key=lambda x: x[1][1]):
             print('"{:s}", {:d}, {:d}'.format(name, stat[0], stat[1] / 8))
 
@@ -246,23 +246,23 @@ def main():
         for f in files:
             captured.append(pattern.match(f).group(1))
             if len(captured) == 8:
-                print >> sys.stdout, captured[0:8]
+                print(captured[0:8])
                 captured = []
-        print >> sys.stdout, captured
+        print(captured)
         return
 
     # Diff two protocols
     if args.diff and args.diff is not None:
         version_list = args.diff.split(',')
         if len(version_list) < 2:
-            print >> sys.stderr, "--diff requires two versions separated by comma e.g. --diff=1,2"
+            print("--diff requires two versions separated by comma e.g. --diff=1,2")
             sys.exit(1)
         diff.diff(version_list[0], version_list[1])
         return
 
     # Check/test the replay file
     if args.replay_file is None:
-        print >> sys.stderr, ".S2Replay file not specified"
+        print(".S2Replay file not specified")
         sys.exit(1)
 
     archive = mpyq.MPQArchive(args.replay_file)
@@ -297,7 +297,8 @@ def main():
     try:
         protocol = versions.build(baseBuild)
     except Exception, e:
-        print >> sys.stderr, 'Unsupported base build: {0} ({1})'.format(baseBuild, str(e))
+        print('Unsupported base build: {0} ({1})'.format(baseBuild, str(e)),
+              file=sys.stderr)
         sys.exit(1)
 
     # Process game metadata
@@ -362,13 +363,13 @@ def main():
 
     if args.profile:
         pr.disable()
-        print "Profiler Results"
-        print "----------------"
+        print("Profiler Results")
+        print("----------------")
         s = StringIO.StringIO()
         sortby = 'cumulative'
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()
-        print s.getvalue()
+        print(s.getvalue())
 
 if __name__ == '__main__':
     main()

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -102,7 +102,7 @@ def convert_fourcc(fourcc_hex):
     represpentation to a string.
     """
     s = []
-    for i in xrange(0, 7, 2):
+    for i in range(0, 7, 2):
         n = int(fourcc_hex[i:i+2], 16)
         if n is not 0:
             s.append(chr(n))

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -296,8 +296,8 @@ def main():
     baseBuild = header['m_version']['m_baseBuild']
     try:
         protocol = versions.build(baseBuild)
-    except Exception, e:
-        print('Unsupported base build: {0} ({1})'.format(baseBuild, str(e)),
+    except Exception as e:
+        print('Unsupported base build: {0} ({1!s})'.format(baseBuild, e),
               file=sys.stderr)
         sys.exit(1)
 

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -93,7 +93,7 @@ class StatCollectionFilter(EventFilter):
     def finish(self):
         print >> sys.stdout, 'Name, Count, Bits'
         for name, stat in sorted(self._event_stats.iteritems(), key=lambda x: x[1][1]):
-            print >> sys.stdout, '"%s", %d, %d' % (name, stat[0], stat[1] / 8)
+            print('"{:s}", {:d}, {:d}'.format(name, stat[0], stat[1] / 8))
 
 
 def convert_fourcc(fourcc_hex):

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -92,7 +92,7 @@ class TypeDumpFilter(EventFilter):
                 return decoded
             elif type(value) is dict:
                 decoded = {}
-                for key, inner_value in value.iteritems():
+                for key, inner_value in value.items():
                     decoded[key] = recurse_into(inner_value)
                 return decoded
             return (type(value).__name__, value)
@@ -115,7 +115,7 @@ class StatCollectionFilter(EventFilter):
 
     def finish(self):
         print('Name, Count, Bits')
-        for name, stat in sorted(self._event_stats.iteritems(), key=lambda x: x[1][1]):
+        for name, stat in sorted(self._event_stats.items(), key=lambda x: x[1][1]):
             print('"{:s}", {:d}, {:d}'.format(name, stat[0], stat[1] / 8))
 
 
@@ -182,10 +182,10 @@ def process_scope_attributes(all_scopes, event_fn):
         attr_id_to_name[_attr.__dict__.get(sym)] = sym.lower()
 
     # Each scope represents a slot in the lobby
-    for scope, scope_dict in all_scopes.iteritems():
+    for scope, scope_dict in all_scopes.items():
         scope_doc = { 'scope': scope }
         # Convert all other attributes to symbolic representation
-        for attr_id, val_dict in scope_dict.iteritems():
+        for attr_id, val_dict in scope_dict.items():
             val = val_dict[0]['value'] 
             attr_name = attr_id_to_name.get(attr_id, None)
             if attr_name is not None:

--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -278,14 +278,15 @@ def main():
     if args.diff and args.diff is not None:
         version_list = args.diff.split(',')
         if len(version_list) < 2:
-            print("--diff requires two versions separated by comma e.g. --diff=1,2")
+            print("--diff requires two versions separated by comma e.g. --diff=1,2",
+                  file=sys.stderr)
             sys.exit(1)
         diff(version_list[0], version_list[1])
         return
 
     # Check/test the replay file
     if args.replay_file is None:
-        print(".S2Replay file not specified")
+        print(".S2Replay file not specified", file=sys.stderr)
         sys.exit(1)
 
     archive = MPQArchive(args.replay_file)

--- a/s2protocol/versions/__init__.py
+++ b/s2protocol/versions/__init__.py
@@ -69,4 +69,3 @@ def build(build_version):
     """
     base_path = os.path.dirname(__file__)
     return _import_protocol(base_path, 'protocol{0:05d}'.format(build_version))
-

--- a/s2protocol/versions/protocol15405.py
+++ b/s2protocol/versions/protocol15405.py
@@ -377,7 +377,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol15405.py
+++ b/s2protocol/versions/protocol15405.py
@@ -271,7 +271,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol16561.py
+++ b/s2protocol/versions/protocol16561.py
@@ -392,7 +392,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol16561.py
+++ b/s2protocol/versions/protocol16561.py
@@ -286,7 +286,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol16605.py
+++ b/s2protocol/versions/protocol16605.py
@@ -392,7 +392,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol16605.py
+++ b/s2protocol/versions/protocol16605.py
@@ -286,7 +286,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol16755.py
+++ b/s2protocol/versions/protocol16755.py
@@ -392,7 +392,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol16755.py
+++ b/s2protocol/versions/protocol16755.py
@@ -286,7 +286,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol16939.py
+++ b/s2protocol/versions/protocol16939.py
@@ -392,7 +392,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol16939.py
+++ b/s2protocol/versions/protocol16939.py
@@ -286,7 +286,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol17266.py
+++ b/s2protocol/versions/protocol17266.py
@@ -398,7 +398,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol17266.py
+++ b/s2protocol/versions/protocol17266.py
@@ -292,7 +292,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol17326.py
+++ b/s2protocol/versions/protocol17326.py
@@ -398,7 +398,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol17326.py
+++ b/s2protocol/versions/protocol17326.py
@@ -292,7 +292,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol18092.py
+++ b/s2protocol/versions/protocol18092.py
@@ -398,7 +398,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol18092.py
+++ b/s2protocol/versions/protocol18092.py
@@ -292,7 +292,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol18468.py
+++ b/s2protocol/versions/protocol18468.py
@@ -398,7 +398,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol18468.py
+++ b/s2protocol/versions/protocol18468.py
@@ -292,7 +292,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol18574.py
+++ b/s2protocol/versions/protocol18574.py
@@ -398,7 +398,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol18574.py
+++ b/s2protocol/versions/protocol18574.py
@@ -292,7 +292,7 @@ replay_initdata_typeid = 54
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol19132.py
+++ b/s2protocol/versions/protocol19132.py
@@ -399,7 +399,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol19132.py
+++ b/s2protocol/versions/protocol19132.py
@@ -293,7 +293,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol19458.py
+++ b/s2protocol/versions/protocol19458.py
@@ -399,7 +399,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol19458.py
+++ b/s2protocol/versions/protocol19458.py
@@ -293,7 +293,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol19595.py
+++ b/s2protocol/versions/protocol19595.py
@@ -399,7 +399,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol19595.py
+++ b/s2protocol/versions/protocol19595.py
@@ -293,7 +293,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol19679.py
+++ b/s2protocol/versions/protocol19679.py
@@ -399,7 +399,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol19679.py
+++ b/s2protocol/versions/protocol19679.py
@@ -293,7 +293,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol21029.py
+++ b/s2protocol/versions/protocol21029.py
@@ -400,7 +400,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol21029.py
+++ b/s2protocol/versions/protocol21029.py
@@ -294,7 +294,7 @@ replay_initdata_typeid = 55
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol22612.py
+++ b/s2protocol/versions/protocol22612.py
@@ -415,7 +415,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol22612.py
+++ b/s2protocol/versions/protocol22612.py
@@ -309,7 +309,7 @@ replay_initdata_typeid = 57
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol23260.py
+++ b/s2protocol/versions/protocol23260.py
@@ -415,7 +415,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol23260.py
+++ b/s2protocol/versions/protocol23260.py
@@ -309,7 +309,7 @@ replay_initdata_typeid = 57
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol24944.py
+++ b/s2protocol/versions/protocol24944.py
@@ -427,7 +427,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol24944.py
+++ b/s2protocol/versions/protocol24944.py
@@ -321,7 +321,7 @@ replay_initdata_typeid = 61
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol26490.py
+++ b/s2protocol/versions/protocol26490.py
@@ -449,7 +449,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol26490.py
+++ b/s2protocol/versions/protocol26490.py
@@ -343,7 +343,7 @@ replay_initdata_typeid = 62
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol27950.py
+++ b/s2protocol/versions/protocol27950.py
@@ -451,7 +451,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol27950.py
+++ b/s2protocol/versions/protocol27950.py
@@ -345,7 +345,7 @@ replay_initdata_typeid = 63
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol28272.py
+++ b/s2protocol/versions/protocol28272.py
@@ -451,7 +451,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol28272.py
+++ b/s2protocol/versions/protocol28272.py
@@ -345,7 +345,7 @@ replay_initdata_typeid = 63
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol28667.py
+++ b/s2protocol/versions/protocol28667.py
@@ -451,7 +451,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol28667.py
+++ b/s2protocol/versions/protocol28667.py
@@ -345,7 +345,7 @@ replay_initdata_typeid = 63
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol32283.py
+++ b/s2protocol/versions/protocol32283.py
@@ -451,7 +451,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol32283.py
+++ b/s2protocol/versions/protocol32283.py
@@ -345,7 +345,7 @@ replay_initdata_typeid = 63
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol51702.py
+++ b/s2protocol/versions/protocol51702.py
@@ -492,7 +492,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol51702.py
+++ b/s2protocol/versions/protocol51702.py
@@ -386,7 +386,7 @@ replay_initdata_typeid = 71
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol52910.py
+++ b/s2protocol/versions/protocol52910.py
@@ -492,7 +492,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol52910.py
+++ b/s2protocol/versions/protocol52910.py
@@ -386,7 +386,7 @@ replay_initdata_typeid = 71
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol53644.py
+++ b/s2protocol/versions/protocol53644.py
@@ -492,7 +492,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol53644.py
+++ b/s2protocol/versions/protocol53644.py
@@ -386,7 +386,7 @@ replay_initdata_typeid = 71
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol54518.py
+++ b/s2protocol/versions/protocol54518.py
@@ -493,7 +493,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol54518.py
+++ b/s2protocol/versions/protocol54518.py
@@ -387,7 +387,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol55505.py
+++ b/s2protocol/versions/protocol55505.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol55505.py
+++ b/s2protocol/versions/protocol55505.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol55958.py
+++ b/s2protocol/versions/protocol55958.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol55958.py
+++ b/s2protocol/versions/protocol55958.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol56787.py
+++ b/s2protocol/versions/protocol56787.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol56787.py
+++ b/s2protocol/versions/protocol56787.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol57507.py
+++ b/s2protocol/versions/protocol57507.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol57507.py
+++ b/s2protocol/versions/protocol57507.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol58400.py
+++ b/s2protocol/versions/protocol58400.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol58400.py
+++ b/s2protocol/versions/protocol58400.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol59587.py
+++ b/s2protocol/versions/protocol59587.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol59587.py
+++ b/s2protocol/versions/protocol59587.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol60196.py
+++ b/s2protocol/versions/protocol60196.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol60196.py
+++ b/s2protocol/versions/protocol60196.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol60321.py
+++ b/s2protocol/versions/protocol60321.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol60321.py
+++ b/s2protocol/versions/protocol60321.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol62347.py
+++ b/s2protocol/versions/protocol62347.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol62347.py
+++ b/s2protocol/versions/protocol62347.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol62848.py
+++ b/s2protocol/versions/protocol62848.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol62848.py
+++ b/s2protocol/versions/protocol62848.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol63454.py
+++ b/s2protocol/versions/protocol63454.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol63454.py
+++ b/s2protocol/versions/protocol63454.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol64469.py
+++ b/s2protocol/versions/protocol64469.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol64469.py
+++ b/s2protocol/versions/protocol64469.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol65094.py
+++ b/s2protocol/versions/protocol65094.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol65094.py
+++ b/s2protocol/versions/protocol65094.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol65384.py
+++ b/s2protocol/versions/protocol65384.py
@@ -495,7 +495,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol65384.py
+++ b/s2protocol/versions/protocol65384.py
@@ -389,7 +389,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol65895.py
+++ b/s2protocol/versions/protocol65895.py
@@ -500,7 +500,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol65895.py
+++ b/s2protocol/versions/protocol65895.py
@@ -394,7 +394,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol66668.py
+++ b/s2protocol/versions/protocol66668.py
@@ -500,7 +500,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol66668.py
+++ b/s2protocol/versions/protocol66668.py
@@ -394,7 +394,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol67188.py
+++ b/s2protocol/versions/protocol67188.py
@@ -500,7 +500,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol67188.py
+++ b/s2protocol/versions/protocol67188.py
@@ -394,7 +394,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol67926.py
+++ b/s2protocol/versions/protocol67926.py
@@ -500,7 +500,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol67926.py
+++ b/s2protocol/versions/protocol67926.py
@@ -394,7 +394,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol69232.py
+++ b/s2protocol/versions/protocol69232.py
@@ -500,7 +500,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol69232.py
+++ b/s2protocol/versions/protocol69232.py
@@ -394,7 +394,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol70154.py
+++ b/s2protocol/versions/protocol70154.py
@@ -501,7 +501,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol70154.py
+++ b/s2protocol/versions/protocol70154.py
@@ -395,7 +395,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol71061.py
+++ b/s2protocol/versions/protocol71061.py
@@ -501,7 +501,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol71061.py
+++ b/s2protocol/versions/protocol71061.py
@@ -395,7 +395,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol71523.py
+++ b/s2protocol/versions/protocol71523.py
@@ -501,7 +501,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol71523.py
+++ b/s2protocol/versions/protocol71523.py
@@ -395,7 +395,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol71663.py
+++ b/s2protocol/versions/protocol71663.py
@@ -501,7 +501,7 @@ def decode_replay_attributes_events(contents):
             value['namespace'] = buffer.read_bits(32)
             value['attrid'] = attrid = buffer.read_bits(32)
             scope = buffer.read_bits(8)
-            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip('\x00')
+            value['value'] = buffer.read_aligned_bytes(4)[::-1].strip(b'\x00')
             if not scope in attributes['scopes']:
                 attributes['scopes'][scope] = {}
             if not attrid in attributes['scopes'][scope]:

--- a/s2protocol/versions/protocol71663.py
+++ b/s2protocol/versions/protocol71663.py
@@ -395,7 +395,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/s2protocol/versions/protocol72282.py
+++ b/s2protocol/versions/protocol72282.py
@@ -395,7 +395,7 @@ replay_initdata_typeid = 73
 
 def _varuint32_value(value):
     # Returns the numeric value from a SVarUint32 instance.
-    for k,v in value.iteritems():
+    for k,v in value.items():
         return v
     return 0
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         's2protocol',
         's2protocol.versions',
     ],
-    scripts=['s2protocol/s2_cli.py'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -46,6 +45,7 @@ setup(
     entry_points={
         'console_scripts': [
             's2protocol = s2protocol.s2protocol:main',
+            's2_cli.py = s2protocol.s2_cli:main',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import s2protocol.build
 
 install_requires = [
     'mpyq >= 0.2.2',
-    'six >= 1.12.0, < 1.13',
 ]
 tests_require = [
     'tox',

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,13 @@ import s2protocol.build
 
 install_requires = [
     'mpyq >= 0.2.2',
+    'six >= 1.12.0, < 1.13',
+]
+tests_require = [
+    'tox',
 ]
 
-if float(sys.version[:3]) < 2.7:
+if sys.version_info < (2, 7):
     install_requires.append('argparse')
 
 
@@ -36,9 +40,10 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: System :: Archiving',
     ],
-    install_requires=[
-        'mpyq'
-    ],
+    install_requires=install_requires,
+    extras_require={
+        'tests': tests_require,
+    },
     entry_points={
         'console_scripts': [
             's2protocol = s2protocol.s2protocol:main',

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -19,8 +19,8 @@ class FilesTestCase(unittest.TestCase):
         base_build = header['m_version']['m_baseBuild']
         try:
             protocol = versions.build(base_build)
-        except Exception, e:
-            self.fail('Unsupported base build: {0} ({1})'.format(base_build, str(e)))
+        except Exception as e:
+            self.fail('Unsupported base build: {0} ({1!s})'.format(base_build, e))
 
         required_internal_files = ['replay.details',
                           'replay.details.backup',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,12 @@
 [tox]
-envlist = py27,py36,py37
+envlist = {py27,py36,py37}-{cli,suite}
+
+[base]
+deps=-e .[tests]
 
 [testenv]
-deps=-e .[tests]
+deps=
+    {[base]deps}
 commands=
-    python tests/suite.py
+    suite: python tests/suite.py
+    cli: s2_cli.py --all --ndjson --profile tests/s2replaystatsdata/2018_05_17_Z_Raphtor_VS_T_Tocon.SC2Replay

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py36,py37
+
+[testenv]
+deps=-e .[tests]
+commands=
+    python tests/suite.py


### PR DESCRIPTION
- Modified `setup.py` to use `install_requires` correctly.
- Used [tox](https://pypi.org/project/tox/) to run on a various version of Python.
- Added compatibility function for `ord`. As I mentioned in [here](https://github.com/Blizzard/s2protocol/pull/85#discussion_r253532132), It needs to support both Python2 and Python3.
- Replace % syntax to `str.format()`.
- Replace `xrange()` into `range()`.
- Replace `.iteritems()` into `items()`.
- Used print function.
- Create s2_cli.py command