### PR TITLE
Fix imports in s2protocol cli script

### DIFF
--- a/s2protocol/s2_cli.py
+++ b/s2protocol/s2_cli.py
@@ -9,9 +9,9 @@ import binascii
 
 import mpyq
 
-import versions
-import diff
-import attributes as _attr
+from s2protocol import versions
+from s2protocol import diff
+from s2protocol import attributes as _attr
 
 import cProfile
 import pstats


### PR DESCRIPTION
This makes it so the script is actually usable as a proper python package outside of the directory in git. If you do python setup.py install right now the script is broken. I would also be happy to convert the argparse to something like click which is much better to work with for CLI python applications in my opinion. 