### PR TITLE
Formatted instructions for documentation generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,7 @@
 ### Generating documentation using Sphinx
 
-pip install Sphinx
-make html
-
+    pip install Sphinx
+    make html
 
 ### Data Definitions
 


### PR DESCRIPTION
I added 4 white spaces in front of the shell instructions to generate the documentation. This way, they are properly displayed as code blocks when the Markdown is rendered as HTML.