### PR TITLE
Region ID for Singapore server (SEA Region)

### DIFF
--- a/docs/flags/details.md
+++ b/docs/flags/details.md
@@ -48,7 +48,7 @@ else if (strpos($cache_handle,hash("sha256","Standard Data: Liberty.SC2Mod")) !=
 (aka team games if a player leaves they dont really know the exact ending of the game). 1 = 1st, 2 = 2nd, ext
 
 **m_playerList->m_toon->m_region**
-> 1 = us, 2 = eu, 3 = kr, 4 = sea, 5 = cn, 98 = local battle.net server (WCS, ext)
+> 1 = US, 2 = EU, 3 = KR, 5 = CN, 6 = SG (SEA; South East Asia), 98 = local battle.net server (WCS, ext)
 
 ####Example Reponse
 ```


### PR DESCRIPTION
https://tl.net/forum/starcraft-2/437452-scelight-60-patch-30-lotv-support?page=16
https://forum.zealothockey.net/viewtopic.php?t=1071
https://www.sc2mapster.com/forums/development/triggers/152901-101-guide-to-player-handles

![Aa5LZ8h](https://user-images.githubusercontent.com/10949969/105996335-859b5f80-60ed-11eb-9f91-e870d81b56dc.png)

This commit corrects misleading documentation regarding player handle's region ID.
As you can see in links and the image attached, the region ID for SEA region is known to be 6, not 4.
It seems like the region number 4 was reserved for something else but it never happened after release of SC2.
